### PR TITLE
#126 - Fixed image resource crash in CheckableFab.

### DIFF
--- a/quiz/src/main/java/com/google/samples/apps/topeka/widget/fab/CheckableFab.kt
+++ b/quiz/src/main/java/com/google/samples/apps/topeka/widget/fab/CheckableFab.kt
@@ -35,7 +35,7 @@ class CheckableFab(
 
     private var _checked = true
 
-    private val attrs: IntArray = intArrayOf(android.R.attr.state_checked)
+    private val attrs = intArrayOf(android.R.attr.state_checked)
 
     init {
         setImageResource(R.drawable.answer_quiz_fab)

--- a/quiz/src/main/java/com/google/samples/apps/topeka/widget/fab/CheckableFab.kt
+++ b/quiz/src/main/java/com/google/samples/apps/topeka/widget/fab/CheckableFab.kt
@@ -35,12 +35,11 @@ class CheckableFab(
 
     private var _checked = true
 
-    init {
-        // TODO #126 fix image resource crash
-//        setImageResource(R.drawable.answer_quiz_fab)
-    }
+    private val attrs: IntArray = intArrayOf(android.R.attr.state_checked)
 
-    private val attrs = intArrayOf(android.R.attr.state_checked)
+    init {
+        setImageResource(R.drawable.answer_quiz_fab)
+    }
 
     override fun onCreateDrawableState(extraSpace: Int): IntArray {
         val drawableState = super.onCreateDrawableState(1 + extraSpace)


### PR DESCRIPTION
App was crashing as `attrs` was `null`. 
This happens because `setImageResource` is called in the constructor and triggers `onCreateDrawableState` with a null value for `attrs`, which is initialised later.

An alternative would be to move `attrs` in a companion object.